### PR TITLE
changed the stderr example in README to use a normal print statement …

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,8 @@ print ('Hello, world')
 sys.stdout.write('Hello, world\n')
 
 # writing to stderr pipe
-print (f'>> {sys.stderr}, "Error occured"')
+print("Error occured")
+sys.stderr.write("Error occured\n")
 
 # reading single line from stdin pipe
 sys.stdout.write('Username: ')


### PR DESCRIPTION
…as f-strings cannot contain a \n. Also added the missing write() method call